### PR TITLE
Runtime Improvements

### DIFF
--- a/src/main/scala/com/azavea/etl/Main.scala
+++ b/src/main/scala/com/azavea/etl/Main.scala
@@ -153,6 +153,7 @@ object Main extends CommandApp(
         logWarn("Shutting down SparkContext")
 
         spark.stop
+        sys.exit(0)
       }
     }
   }

--- a/src/main/scala/com/azavea/etl/Main.scala
+++ b/src/main/scala/com/azavea/etl/Main.scala
@@ -95,7 +95,6 @@ object Main extends CommandApp(
 
         val spark = SparkSession.builder
           .config(conf)
-          .enableHiveSupport
           .getOrCreate
 
         implicit val sc = spark.sparkContext


### PR DESCRIPTION
Removes Hive support. We're not using it, and it causes the jar to hang when spark-submitted in certain cases, breaking scripting workflows.

Also add explicit exit command. In certain cases, the script would still not exit cleanly after finishing the ingest, despite removing Hive support. This explicit call to `sys.exit(0)` ensures that it does.